### PR TITLE
feat: upgrade to Keycloakify v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@emotion/react": "^11.7.0",
     "@gouvfr/dsfr": "^1.5.0",
-    "keycloakify": "v4",
+    "keycloakify": "^5.4.7",
+    "powerhooks": "^0.20.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "tss-react": "^3.6.0"

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,9 +1,9 @@
-import { useState, memo } from "react";
+import { useState, memo, Fragment } from "react";
 import { useConstCallback } from "powerhooks/useConstCallback";
 import type { FormEventHandler } from "react";
-import { KcContextBase, KcProps, useKcMessage } from "keycloakify";
-import { useCssAndCx } from "tss-react";
+import { KcContextBase, KcProps, getMsg } from "keycloakify";
 import { Template } from "./Template";
+
 
 export const Login = memo(
   ({ kcContext, ...props }: { kcContext: KcContextBase.Login } & KcProps) => {
@@ -17,11 +17,9 @@ export const Login = memo(
       registrationDisabled,
     } = kcContext;
 
-    const { msg, msgStr } = useKcMessage();
+    const { msg, msgStr } = getMsg(kcContext);
 
     const [isLoginButtonDisabled, setIsLoginButtonDisabled] = useState(false);
-
-    const { cx } = useCssAndCx();
 
     const onSubmit = useConstCallback<FormEventHandler<HTMLFormElement>>(e => {
       e.preventDefault();
@@ -166,7 +164,7 @@ export const Login = memo(
               <div id="kc-social-providers" className="fr-mt-3w">
                 <ul>
                   {social.providers.map(p => (
-                    <>
+                    <Fragment key={p.alias}>
                       {p.providerId === "franceconnect-particulier" ? (
                         <div
                           className="fr-connect-group"
@@ -218,7 +216,7 @@ export const Login = memo(
                           </a>
                         </li>
                       )}
-                    </>
+                    </Fragment>
                   ))}
                 </ul>
               </div>

--- a/src/Register.tsx
+++ b/src/Register.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { KcProps, useKcMessage } from "keycloakify";
+import { KcProps, getMsg } from "keycloakify";
 import type { KcContext } from "./kcContext";
 import { Template } from "./Template";
 
@@ -16,7 +16,7 @@ export const Register = memo(
       recaptchaSiteKey,
     } = kcContext;
 
-    const { msg, msgStr } = useKcMessage();
+    const { msg, msgStr } = getMsg();
 
     console.log(`TODO: Do something with ${kcContext.authorizedMailDomains}`);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,15 @@
-import ReactDOM from "react-dom";
 import "@gouvfr/dsfr/dist/dsfr/dsfr.min.css";
 import { kcContext } from "./kcContext";
 import { KcApp } from "./KcApp";
+import { createRoot } from "react-dom/client";
+import { StrictMode } from "react";
 
-ReactDOM.render(
-  kcContext === undefined ? <div /> : <KcApp kcContext={kcContext} />,
-  document.getElementById("root")
+if( kcContext === undefined ){
+  throw new Error("No kcContext");
+}
+
+createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <KcApp kcContext={kcContext} />
+    </StrictMode>
 );

--- a/src/kcContext.ts
+++ b/src/kcContext.ts
@@ -25,7 +25,7 @@ export const { kcContext } = getKcContext<
     }
 >({
   /* Uncomment to test outside of keycloak, ⚠️ don't forget to run 'yarn keycloak' at least once */
-  // mockPageId: "login.ftl",
+  //mockPageId: "login.ftl",
   mockData: [
     {
       pageId: "register.ftl",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4054,10 +4054,10 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-evt@2.0.0-beta.39:
-  version "2.0.0-beta.39"
-  resolved "https://registry.yarnpkg.com/evt/-/evt-2.0.0-beta.39.tgz#3c859a83b35940f7eecfb5f148f03b7cbf3fee51"
-  integrity sha512-XxJkaHrFWBrzjTbnr5LJYXkGkADsAXReZfq2lFu3Kf1iCEw5/5ibrdXu3bQdWW6xkZ8qwAHT3STU9zYcCl09BA==
+evt@2.0.0-beta.44:
+  version "2.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/evt/-/evt-2.0.0-beta.44.tgz#7b936e65b3a8c2536e21f1c2af9e85fb95cc32ec"
+  integrity sha512-2XKKP3UhwLY1jOe8Ta0iL44ZZCy8iG1fGRHeyuU8W/aRcpcKy0PFi/FkVhaaI3tkWjqqfNJQ0wRgDovNP6N3KQ==
   dependencies:
     minimal-polyfills "^2.2.1"
     run-exclusive "^2.2.14"
@@ -5725,22 +5725,23 @@ jsonpointer@^5.0.0:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
 
-keycloakify@v4:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/keycloakify/-/keycloakify-4.10.0.tgz#8337d64c025eb7d461ad5d7face82a521ced8992"
-  integrity sha512-rzICgnU0neHVzZnn3eRCL0It2TV3OzMleRROwlVK4Z4e0KbzGkJnE4O/MDdaCs6zhgpLJZPKX82pBzCMJqRguw==
+keycloakify@^5.4.7:
+  version "5.4.7"
+  resolved "https://registry.yarnpkg.com/keycloakify/-/keycloakify-5.4.7.tgz#9d4f6435c12f02883abfe4c3980bdda5897042a1"
+  integrity sha512-yZyPMWvVD2/7aHFf+YzmJzbp4E2hSfQaTnUfFByRSb3JNAZu8BxRRsq7n+OpX0VKbkSuiN/v5ktSY+x+O7jyfg==
   dependencies:
     "@octokit/rest" "^18.12.0"
     cheerio "^1.0.0-rc.5"
     cli-select "^1.1.2"
-    evt "2.0.0-beta.39"
+    evt "2.0.0-beta.44"
+    memoizee "^0.4.15"
     minimal-polyfills "^2.2.1"
     path-browserify "^1.0.1"
-    powerhooks "^0.14.0"
+    powerhooks "^0.20.1"
     react-markdown "^5.0.3"
     scripting-tools "^0.19.13"
-    tsafe "^0.9.0"
-    tss-react "^3.5.2"
+    tsafe "^0.10.0"
+    tss-react "^3.7.0"
 
 kind-of@^6.0.2:
   version "6.0.3"
@@ -7131,15 +7132,15 @@ postcss@^8.1.6, postcss@^8.2.15, postcss@^8.3.5, postcss@^8.4.4:
     picocolors "^1.0.0"
     source-map-js "^1.0.1"
 
-powerhooks@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/powerhooks/-/powerhooks-0.14.0.tgz#44dd201f470761362a139ae2cb51eaa658ed5e3e"
-  integrity sha512-jWrRHyqev7Lh3MId7h1mNxs+fgegr8liHN17AaHxMgrXI6KxJ14B3Pe1It4FIRWJ4Z1dxsA734FerFGZ3Vgdkg==
+powerhooks@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/powerhooks/-/powerhooks-0.20.1.tgz#54e3b391c6037bc39baa9bbf6e94dd8ebbe54126"
+  integrity sha512-f8TmfKEUqpmcS4xsWPGeKuF3ybXR4eHjiOki1Ww/JFiCn1nLr3YkpGKvdF7+WkStv796WqSOi4kqeRN71mLt5g==
   dependencies:
-    evt "2.0.0-beta.39"
+    evt "2.0.0-beta.44"
     memoizee "^0.4.15"
     resize-observer-polyfill "^1.5.1"
-    tsafe "^0.8.1"
+    tsafe "^0.10.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -8428,20 +8429,15 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
+tsafe@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/tsafe/-/tsafe-0.10.0.tgz#c4fba365a49467ea6167e8c9482ddb94ee51b795"
+  integrity sha512-CFfa1uJKfU0DDRbuB8bf2mfXjkOqiTsrltexzMMLxq5gjd1LttFECNGsO8dYUALJDbShb6+f3CwAppW/wf9BrA==
+
 tsafe@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/tsafe/-/tsafe-0.4.1.tgz#00af1be2db82abb4be531209b90232d7954e1a03"
   integrity sha512-+OZ0gdgmwcru+MOSheCx+ymAvQz+1/ui+KFJRuaq0t2m8RNrlf7eSzEieptoPQXPY67Mdkqgkdjknn8azoD5sw==
-
-tsafe@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/tsafe/-/tsafe-0.8.1.tgz#9af7e1540bc04313a82d60c98056a5017c8b086b"
-  integrity sha512-EfPjxQHzndQAV/uh0SMGP26Wg3dCuaw8dRv2VPEuGHen5qzg2oqsMvZw2wkQFkiMisZq2fm95m5lheimW2Fpvg==
-
-tsafe@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/tsafe/-/tsafe-0.9.0.tgz#8394e5fdf81e690c97e2b8be4180a079a4a19bfb"
-  integrity sha512-wmbu8pI/xmW69b13HoS8WbTcSlRTDjIut9ACblBjVZVTk0vsMRXdoh1k1jMu5EzKNohBavKHhqNOOsccSR7XCA==
 
 tsconfig-paths@^3.11.0:
   version "3.12.0"
@@ -8463,10 +8459,19 @@ tslib@^2.0.3, tslib@^2.2.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-tss-react@^3.5.2, tss-react@^3.6.0:
+tss-react@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/tss-react/-/tss-react-3.6.0.tgz#22b58a65a1390507891d6b9ac95f58d22c5cd666"
   integrity sha512-mtQ8VL0btMVZZtax5gwaGU+jSBdKtbYMLVCLGB26Bi+BcOI0GQ6GTn1EaeK1nSgN5qbe6FL0zEOC6qoY+8+MEg==
+  dependencies:
+    "@emotion/cache" "*"
+    "@emotion/serialize" "*"
+    "@emotion/utils" "*"
+
+tss-react@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/tss-react/-/tss-react-3.7.0.tgz#664b4259c36800eb5285a583f6d8c1d5d1d1a30f"
+  integrity sha512-thvJWR+sr3ZGMcV/Ryo1F5RzjXd1gMTzYV/ckfUEBhu701uTYE3KyL9DNxv827uRFPFSLYG7bKefuc7kmYMB9Q==
   dependencies:
     "@emotion/cache" "*"
     "@emotion/serialize" "*"


### PR DESCRIPTION
Hi @revolunet,  

Following up on [our discussion](https://github.com/InseeFrLab/keycloakify/pull/120) here is a PR to upgrade to Keycloakify v5.  

![image](https://user-images.githubusercontent.com/6702424/175100525-7b3c57d2-10cc-42af-a4de-caa31ad2c821.png)


I should mention that it's now better to overload `register-user-profile.ftl` rather than `register.ftl`, Keycloak didn't remove `register.ftl` only for backward compatibility but it can now be considered legacy.  See this https://docs.keycloakify.dev/realtime-input-validation  

Best regards